### PR TITLE
split_header yaml to scl changing format.

### DIFF
--- a/content/split_header.lua
+++ b/content/split_header.lua
@@ -1,5 +1,5 @@
 function content.split_header (document_text)
-  local yaml_text, body = document_text:match("(.-)\n%.%.%.*\n?(.*)")
-  local header = yaml.to_table(yaml_text)
+  local scl_text, body = document_text:match("---\n(.*)\n...")
+  local header = scl.to_table(scl_text)
   return header, body
 end


### PR DESCRIPTION
This should be a temporary modification.
The pattern is pretty ugly and `body` is `nil`.